### PR TITLE
Fix reflection

### DIFF
--- a/src/boundary_geometry.py
+++ b/src/boundary_geometry.py
@@ -63,8 +63,10 @@ class Boundary(ABC):
         return new_pt
 
     @abstractmethod
-    def reflect_velocity(self, pt, vel):
-        return vel
+    def reflect_velocity(self, old_pt, new_pt):
+        vel_angle = np.arctan2(new_pt[1] - old_pt[1], new_pt[0] - old_pt[0])
+        return vel_angle
+
 
 ## a rectangular domain using virtual boundary.
 # This domain implements a virtual boundary so that sensors don't get
@@ -108,7 +110,7 @@ class RectangularDomain(Boundary):
         return points
 
     ## Generate points distributed randomly (uniformly) in the interior.
-    def generate_interior_points(self, n_int_sensors: int)-> list:
+    def generate_interior_points(self, n_int_sensors: int) -> list:
         rand_x = np.random.uniform(self.x_min, self.x_max, size=n_int_sensors)
         rand_y = np.random.uniform(self.y_min, self.y_max, size=n_int_sensors)
         return list(zip(rand_x, rand_y))
@@ -128,5 +130,11 @@ class RectangularDomain(Boundary):
 
         return pt
 
-    def reflect_velocity(self, pt, vel):
-        return vel
+    def reflect_velocity(self, old_pt, new_pt):
+        vel_angle = np.arctan2(new_pt[1] - old_pt[1], new_pt[0] - old_pt[0])
+        if new_pt[0] <= self.x_min or new_pt[0] >= self.x_max:
+            vel_angle = np.pi - vel_angle
+        if new_pt[1] <= self.y_min or new_pt[1] >= self.y_max:
+            vel_angle = - vel_angle
+        vel_angle %= 2 * np.pi
+        return vel_angle % (2 * np.pi)

--- a/src/boundary_geometry.py
+++ b/src/boundary_geometry.py
@@ -58,7 +58,7 @@ class Boundary(ABC):
         a = [str(n + 1) + "," + str(n) for n in range(len(self.points) - 1)] + ["0," + str(len(self.points) - 1)]
         return tuple(sorted(a))
 
-    def reflect(self, old_pt, new_pt):
+    def reflect_point(self, old_pt, new_pt):
         return new_pt
 
 

--- a/src/boundary_geometry.py
+++ b/src/boundary_geometry.py
@@ -58,6 +58,9 @@ class Boundary(ABC):
         a = [str(n + 1) + "," + str(n) for n in range(len(self.points) - 1)] + ["0," + str(len(self.points) - 1)]
         return tuple(sorted(a))
 
+    def reflect(self, old_pt, new_pt):
+        return new_pt
+
 
 ## a rectangular domain using virtual boundary.
 # This domain implements a virtual boundary so that sensors don't get
@@ -104,4 +107,3 @@ class RectangularDomain(Boundary):
         rand_x = np.random.uniform(self.x_min, self.x_max, size=n_int_sensors)
         rand_y = np.random.uniform(self.y_min, self.y_max, size=n_int_sensors)
         return list(zip(rand_x, rand_y))
-

--- a/src/boundary_geometry.py
+++ b/src/boundary_geometry.py
@@ -62,6 +62,9 @@ class Boundary(ABC):
     def reflect_point(self, old_pt, new_pt):
         return new_pt
 
+    @abstractmethod
+    def reflect_velocity(self, pt, vel):
+        return vel
 
 ## a rectangular domain using virtual boundary.
 # This domain implements a virtual boundary so that sensors don't get
@@ -124,3 +127,6 @@ class RectangularDomain(Boundary):
             pt = (new_pt[0], self.y_max - abs(self.y_max - new_pt[1]))
 
         return pt
+
+    def reflect_velocity(self, pt, vel):
+        return vel

--- a/src/boundary_geometry.py
+++ b/src/boundary_geometry.py
@@ -92,7 +92,8 @@ class RectangularDomain(Boundary):
 
     ## Check if point is in virtual domain.
     def in_domain(self, point: tuple) -> bool:
-        return self.x_min < point[0] < self.x_max and self.y_min < point[1] < self.y_max
+        return self.x_min < point[0] < self.x_max \
+               and self.y_min < point[1] < self.y_max
 
     ## Generate points in counter-clockwise order.
     def generate_boundary_points(self) -> list:
@@ -111,15 +112,15 @@ class RectangularDomain(Boundary):
 
     def reflect_point(self, old_pt, new_pt):
         pt = new_pt
-        if old_pt[0] <= self.x_min:
+        if new_pt[0] <= self.x_min:
             pt = (self.x_min + abs(self.x_min - new_pt[0]), new_pt[1])
-        elif old_pt[0] >= self.x_max:
+        elif new_pt[0] >= self.x_max:
             pt = (self.x_max - abs(self.x_max - new_pt[0]), new_pt[1])
 
         new_pt = pt
-        if old_pt[1] <= self.y_min:
+        if new_pt[1] <= self.y_min:
             pt = (new_pt[0], self.y_min + abs(self.y_min - new_pt[1]))
-        elif old_pt[1] >= self.y_max:
+        elif new_pt[1] >= self.y_max:
             pt = (new_pt[0], self.y_max - abs(self.y_max - new_pt[1]))
 
         return pt

--- a/src/boundary_geometry.py
+++ b/src/boundary_geometry.py
@@ -58,6 +58,7 @@ class Boundary(ABC):
         a = [str(n + 1) + "," + str(n) for n in range(len(self.points) - 1)] + ["0," + str(len(self.points) - 1)]
         return tuple(sorted(a))
 
+    @abstractmethod
     def reflect_point(self, old_pt, new_pt):
         return new_pt
 
@@ -107,3 +108,18 @@ class RectangularDomain(Boundary):
         rand_x = np.random.uniform(self.x_min, self.x_max, size=n_int_sensors)
         rand_y = np.random.uniform(self.y_min, self.y_max, size=n_int_sensors)
         return list(zip(rand_x, rand_y))
+
+    def reflect_point(self, old_pt, new_pt):
+        pt = new_pt
+        if old_pt[0] <= self.x_min:
+            pt = (self.x_min + abs(self.x_min - new_pt[0]), new_pt[1])
+        elif old_pt[0] >= self.x_max:
+            pt = (self.x_max - abs(self.x_max - new_pt[0]), new_pt[1])
+
+        new_pt = pt
+        if old_pt[1] <= self.y_min:
+            pt = (new_pt[0], self.y_min + abs(self.y_min - new_pt[1]))
+        elif old_pt[1] >= self.y_max:
+            pt = (new_pt[0], self.y_max - abs(self.y_max - new_pt[1]))
+
+        return pt

--- a/src/motion_model.py
+++ b/src/motion_model.py
@@ -51,7 +51,7 @@ class MotionModel(ABC):
         for (n, pt) in enumerate(interior_pts):
             interior_pts[n] = self.update_point(pt, offset+n)
             if not self.boundary.in_domain(interior_pts[n]):
-                interior_pts[n] = self.reflect(pt, offset+n)
+                interior_pts[n] = self.boundary.reflect(interior_pts[n], self.reflect(pt, offset+n))
 
         return self.boundary.points + interior_pts
 

--- a/src/motion_model.py
+++ b/src/motion_model.py
@@ -128,19 +128,7 @@ class BilliardMotion(MotionModel):
 
     ## Reflect using angle in = angle out.
     def reflect_point(self, old_pt: tuple, new_pt: tuple) -> tuple:
-        pt = new_pt
-        if old_pt[0] <= self.boundary.x_min:
-            pt = (self.boundary.x_min + abs(self.boundary.x_min - new_pt[0]), new_pt[1])
-        elif old_pt[0] >= self.boundary.x_max:
-            pt = (self.boundary.x_max - abs(self.boundary.x_max - new_pt[0]), new_pt[1])
-
-        new_pt = pt
-        if old_pt[1] <= self.boundary.y_min:
-            pt = (new_pt[0], self.boundary.y_min + abs(self.boundary.y_min - new_pt[1]))
-        elif old_pt[1] >= self.boundary.y_max:
-            pt = (new_pt[0], self.boundary.y_max - abs(self.boundary.y_max - new_pt[1]))
-
-        return pt
+        return new_pt
 
 
 ## Implement randomized variant of Billiard motion.

--- a/src/motion_model.py
+++ b/src/motion_model.py
@@ -55,7 +55,7 @@ class MotionModel(ABC):
         for (n, pt) in enumerate(interior_pts):
             interior_pts[n] = self.update_point(pt, offset+n)
             if not self.boundary.in_domain(interior_pts[n]):
-                interior_pts[n] = self.boundary.reflect_point(pt, self.reflect_point(pt, interior_pts[n]))
+                interior_pts[n] = self.boundary.reflect_point(pt, interior_pts[n])
                 self.reflect_velocity(pt, offset+n)
 
         return self.boundary.points + interior_pts

--- a/src/motion_model.py
+++ b/src/motion_model.py
@@ -40,7 +40,8 @@ class MotionModel(ABC):
     # If a point is not in the domain, reflect. It is sometimes
     # necessary to override this class method since this method is
     # called only once per time-step.
-    def update_points(self, old_points: list) -> list:
+    def update_points(self, old_points: list, dt: float) -> list:
+        self.dt = dt
         return self.boundary.points \
             + [self.update_point(pt, n) for n, pt in enumerate(old_points) if n >= len(self.boundary)]
 
@@ -60,9 +61,9 @@ class BrownianMotion(MotionModel):
         return self.sigma * sqrt(self.dt) * random.normal(0, 1)
 
     ## Update each coordinate with brownian model.
-    def update_point(self, pt: tuple, index=0) -> tuple:
-        new_pt = pt[0] + self.epsilon(), pt[1] + self.epsilon()
-        return new_pt if self.boundary.in_domain(new_pt) else self.reflect(pt, new_pt, index)
+    def update_point(self, old_pt: tuple, index) -> tuple:
+        new_pt = old_pt[0] + self.epsilon(), old_pt[1] + self.epsilon()
+        return new_pt if self.boundary.in_domain(new_pt) else self.reflect(old_pt, new_pt, index)
 
     def reflect(self, old_pt, new_pt, index):
         return self.boundary.reflect_point(old_pt, new_pt)

--- a/src/time_stepping.py
+++ b/src/time_stepping.py
@@ -93,7 +93,7 @@ class EvasionPathSimulation:
 
             # Update Points
             if level == 0:
-                self.points = self.motion_model.update_points(self.points)
+                self.points = self.motion_model.update_points(self.points, self.dt)
             else:
                 self.points = self.interpolate_points(self.old_points, new_points, t)
 

--- a/src/time_stepping.py
+++ b/src/time_stepping.py
@@ -59,7 +59,6 @@ class EvasionPathSimulation:
 
         # Point data
         self.points = boundary.generate_points(n_int_sensors)
-        self.old_points = self.points
 
         self.state = TopologicalState(self.points, self.sensing_radius, self.boundary)
         self.old_state = self.state
@@ -68,7 +67,6 @@ class EvasionPathSimulation:
 
     ## Move to next time-step.
     def update_old_data(self) -> None:
-        self.old_points = self.points.copy()
         self.old_state = deepcopy(self.state)
 
     ## Run until no more intruders.
@@ -84,39 +82,28 @@ class EvasionPathSimulation:
 
     ## To single timestep.
     # Do recursive adaptive step if non-atomic transition is found.
-    def do_timestep(self, new_points: list = (), level: int = 0) -> None:
+    def do_timestep(self, level: int = 0) -> None:
+
+        dt = self.dt * 2 ** -(level+1)
 
         if level == 25:
             raise MaxRecursionDepth(self.state_change)
 
-        for t in [0.5, 1.0]:
+        for _ in range(2):
 
-            # Update Points
-            if level == 0:
-                self.points = self.motion_model.update_points(self.points, self.dt)
-            else:
-                self.points = self.interpolate_points(self.old_points, new_points, t)
-
-            self.state = TopologicalState(self.points, self.sensing_radius, self.boundary)
+            new_points = self.motion_model.update_points(self.points, dt)
+            self.state = TopologicalState(new_points, self.sensing_radius, self.boundary)
             self.state_change = StateChange(self.old_state, self.state)
 
             try:
                 self.cycle_label.update(self.state_change)
+                self.points = new_points
 
             except InvalidStateChange:
-                self.do_timestep(self.points, level=level + 1)
+                self.do_timestep(level=level + 1)
 
-            self.n_steps += 1
             self.is_connected = self.is_connected and self.state.is_connected()
             self.update_old_data()
 
             if level == 0:
                 return
-
-    ## Linearly interpolate points.
-    # Used when doing an adaptive step to interpolate between old an new points.
-    @staticmethod
-    def interpolate_points(old_points: list, new_points: list, t: float) -> list:
-        return [(old_points[n][0] * (1 - t) + new_points[n][0] * t,
-                 old_points[n][1] * (1 - t) + new_points[n][1] * t)
-                for n in range(len(old_points))]

--- a/src/time_stepping.py
+++ b/src/time_stepping.py
@@ -73,7 +73,7 @@ class EvasionPathSimulation:
     # exit if max time is set. Returns simulation time.
     def run(self) -> float:
         while self.cycle_label.has_intruder():
-            self.time += self.dt
+            # self.time += self.dt
             self.evasion_paths = ""
             self.do_timestep()
             if 0 < self.Tend < self.time:
@@ -95,15 +95,14 @@ class EvasionPathSimulation:
             self.state = TopologicalState(new_points, self.sensing_radius, self.boundary)
             self.state_change = StateChange(self.old_state, self.state)
 
-            try:
+            if self.state_change.is_atomic():
                 self.cycle_label.update(self.state_change)
+                self.time += dt
                 self.points = new_points
-
-            except InvalidStateChange:
+                self.is_connected &= self.state.is_connected()
+                self.update_old_data()
+            else:
                 self.do_timestep(level=level + 1)
-
-            self.is_connected = self.is_connected and self.state.is_connected()
-            self.update_old_data()
 
             if level == 0:
                 return


### PR DESCRIPTION
This pr overhauls how the reflection is handled entirely as well as the adaptive time-stepping (specifically in deterministic cases). 

The main idea is that reflection is a purely geometric idea when handled elastically and should be handled by the boundary class instead of the motion model; additionally, reflection position, and reflection velocities should be treated separately. 

Along the way it was realized that linear interpolation does not mesh well with reflecting off the walls, and that for purly deterministic cases we do not actually need linear interpolation and can simply compute the intermediate values needed. 

The pr address #18 #2 #12 #5 